### PR TITLE
The Unicode object has a decode() method because

### DIFF
--- a/featmongo/serializer.py
+++ b/featmongo/serializer.py
@@ -52,7 +52,7 @@ class Serializer(base.Serializer):
     def flatten_key(self, key, caps, freezing):
         if not isinstance(key, str):
             if isinstance(key, unicode) and self._force_unicode:
-                pass
+                return key
             else:
                 raise TypeError("Serializer %s is not capable of serializing "
                                 "non-string dictionary keys: %r"


### PR DESCRIPTION
it inherits from basestring and basestring has one.
It's semantics are meaningless
and can raise UnicodeEncodeError
